### PR TITLE
fix: updated deprecated v8 API for Node 12 (fixes #39)

### DIFF
--- a/bindings/sampling-heap-profiler.cc
+++ b/bindings/sampling-heap-profiler.cc
@@ -62,8 +62,8 @@ NAN_METHOD(StartSamplingHeapProfiler) {
     if (!info[1]->IsNumber()) {
       return Nan::ThrowTypeError("Second argument type must be an integer.");
     }
-    uint64_t sample_interval = info[0].As<Integer>()->Uint32Value();
-    int stack_depth = info[1].As<Integer>()->IntegerValue();
+    uint64_t sample_interval = info[0].As<Integer>()->Uint32Value(Nan::GetCurrentContext()).FromJust();
+    int stack_depth = info[1].As<Integer>()->IntegerValue(Nan::GetCurrentContext()).FromJust();
     info.GetIsolate()->GetHeapProfiler()->
       StartSamplingHeapProfiler(sample_interval, stack_depth);
   } else {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "bindings": "^1.5.0",
-    "nan": "^2.13.2",
+    "nan": "^2.14.0",
     "pify": "^3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This is a small fix for deprecated APIs for v7.5. Fixes #39 