### PR TITLE
Use Nan::Set to accommodate for Node 14+

### DIFF
--- a/bindings/sampling-heap-profiler.cc
+++ b/bindings/sampling-heap-profiler.cc
@@ -23,34 +23,65 @@ using namespace v8;
 
 Local<Value> TranslateAllocationProfile(AllocationProfile::Node* node) {
   Local<Object> js_node = Nan::New<Object>();
-  js_node->Set(Nan::New<String>("name").ToLocalChecked(),
-    node->name);
-  js_node->Set(Nan::New<String>("scriptName").ToLocalChecked(),
-    node->script_name);
-  js_node->Set(Nan::New<String>("scriptId").ToLocalChecked(),
-    Nan::New<Integer>(node->script_id));
-  js_node->Set(Nan::New<String>("lineNumber").ToLocalChecked(),
-    Nan::New<Integer>(node->line_number));
-  js_node->Set(Nan::New<String>("columnNumber").ToLocalChecked(),
-    Nan::New<Integer>(node->column_number));
+  Nan::Set(
+    js_node,
+    Nan::New<String>("name").ToLocalChecked(),
+    node->name
+  );
+  Nan::Set(
+    js_node,
+    Nan::New<String>("scriptName").ToLocalChecked(),
+    node->script_name
+  );
+  Nan::Set(
+    js_node,
+    Nan::New<String>("scriptId").ToLocalChecked(),
+    Nan::New<Integer>(node->script_id)
+  );
+  Nan::Set(
+    js_node,
+    Nan::New<String>("lineNumber").ToLocalChecked(),
+    Nan::New<Integer>(node->line_number)
+  );
+  Nan::Set(
+    js_node,
+    Nan::New<String>("columnNumber").ToLocalChecked(),
+    Nan::New<Integer>(node->column_number)
+  );
   Local<Array> children = Nan::New<Array>(node->children.size());
   for (size_t i = 0; i < node->children.size(); i++) {
-    children->Set(i, TranslateAllocationProfile(node->children[i]));
+    Nan::Set(children, i, TranslateAllocationProfile(node->children[i]));
   }
-  js_node->Set(Nan::New<String>("children").ToLocalChecked(),
-    children);
+  Nan::Set(
+    js_node,
+    Nan::New<String>("children").ToLocalChecked(),
+    children
+  );
   Local<Array> allocations = Nan::New<Array>(node->allocations.size());
   for (size_t i = 0; i < node->allocations.size(); i++) {
     AllocationProfile::Allocation alloc = node->allocations[i];
     Local<Object> js_alloc = Nan::New<Object>();
-    js_alloc->Set(Nan::New<String>("size").ToLocalChecked(),
-      Nan::New<Number>(alloc.size));
-    js_alloc->Set(Nan::New<String>("count").ToLocalChecked(),
-      Nan::New<Number>(alloc.count));
-    allocations->Set(i, js_alloc);
+    Nan::Set(
+      js_alloc,
+      Nan::New<String>("size").ToLocalChecked(),
+      Nan::New<Number>(alloc.size)
+    );
+    Nan::Set(
+      js_alloc,
+      Nan::New<String>("count").ToLocalChecked(),
+      Nan::New<Number>(alloc.count)
+    );
+    Nan::Set(
+      allocations,
+      i,
+      js_alloc
+    );
   }
-  js_node->Set(Nan::New<String>("allocations").ToLocalChecked(),
-    allocations);
+  Nan::Set(
+    js_node,
+    Nan::New<String>("allocations").ToLocalChecked(),
+    allocations
+  );
   return js_node;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4003,9 +4003,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.13.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
-      "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw=="
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
     },
     "nanomatch": {
       "version": "1.2.13",


### PR DESCRIPTION
When trying to build `heap-profile` with Node 14+ (warns on 12+, fails on 14+), the node-gyp compilation fails:

```
../bindings/sampling-heap-profiler.cc:26:12: error: no matching member function for call to 'Set'
  js_node->Set(Nan::New<String>("name").ToLocalChecked(),
  ~~~~~~~~~^~~
{path}/node-gyp/14.15.0/include/node/v8.h:3670:37: note: candidate function not viable: requires 3 arguments, but 2 were provided
  V8_WARN_UNUSED_RESULT Maybe<bool> Set(Local<Context> context,
```

Looking at the Nan docs suggests that we could instead use [`Nan::Set`](https://github.com/nodejs/nan/blob/HEAD/doc/maybe_types.md#api_nan_set) to set object properties in a version-independent way.